### PR TITLE
node 10 docker image

### DIFF
--- a/Dockerfile_node
+++ b/Dockerfile_node
@@ -1,4 +1,4 @@
-FROM node:13.8.0-alpine
+FROM node:10.19.0-alpine
 
 ENV PATH="./node_modules/.bin:${PATH}"
 ENV SHELL /bin/bash


### PR DESCRIPTION
One-off, need for compatibility with a native module (@mapbox/mapbox-gl-native). Will roll back after image has been pushed.