### PR TITLE
Add g++ as a core dependency.

### DIFF
--- a/shared/core_deps.sh
+++ b/shared/core_deps.sh
@@ -8,6 +8,7 @@ apk add --no-cache --virtual=dependencies \
   libc-dev \
   libffi-dev \
   gcc \
+  g++ \
   python3-dev
 
 # packages


### PR DESCRIPTION
G++ is required by a package installed during the _planning-scrapers_ tests.