### PR TITLE
Drop node 12 build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,18 +120,6 @@ workflow_jobs: &workflow_jobs
             only:
               - master
     
-    # Is this needed? No references in github.
-    - legacy_node:
-        name: legacy_node_v12
-        node_version: "12"
-        context: DockerHub
-        requires:
-          - node
-        filters:
-          branches:
-            only:
-              - master
-    
     - kubernetes:
         context: DockerHub
         requires:


### PR DESCRIPTION
Not used specifically in any LT projects and the build is broken. The image will stay in Dockerhub, though we will no longer support node 12.

We should also let engineers know that this is being deprecated.