### PR TITLE
Use go install rather than go get for kops image

### DIFF
--- a/Dockerfile_kops
+++ b/Dockerfile_kops
@@ -7,9 +7,9 @@ RUN apk add curl \
 
 FROM golang:alpine as golang
 RUN apk add git \
-  && go install github.com/google/go-jsonnet/cmd/jsonnet \
-  && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb \
-  && go install github.com/brancz/gojsontoyaml
+  && go install github.com/google/go-jsonnet/cmd/jsonnet@latest \
+  && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest \
+  && go install github.com/brancz/gojsontoyaml@latest
 
 FROM landtech/ci-kubernetes:latest
 COPY --from=kops /usr/local/bin/kops /usr/local/bin

--- a/Dockerfile_kops
+++ b/Dockerfile_kops
@@ -7,9 +7,9 @@ RUN apk add curl \
 
 FROM golang:alpine as golang
 RUN apk add git \
-  && go get github.com/google/go-jsonnet/cmd/jsonnet \
-  && go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb \
-  && go get github.com/brancz/gojsontoyaml
+  && go install github.com/google/go-jsonnet/cmd/jsonnet \
+  && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb \
+  && go install github.com/brancz/gojsontoyaml
 
 FROM landtech/ci-kubernetes:latest
 COPY --from=kops /usr/local/bin/kops /usr/local/bin


### PR DESCRIPTION
Golang 1.18 came out on Tuesday which I believe has deprecated some `go get` behaviour.

The deprecation (starting in 1.17) is noted here: https://go.dev/doc/go-get-install-deprecation

Golang 1.18 blog entry is here: https://go.dev/blog/go1.18
Golang 1.18 release notes are here: https://go.dev/doc/go1.18 (search `go install`)

Snippet from that last link:
> go get no longer builds or installs packages in module-aware mode. go get is now dedicated to adjusting dependencies in go.mod. Effectively, the -d flag is always enabled. To install the latest version of an executable outside the context of the current module, use [go install example.com/cmd@latest](https://golang.org/ref/mod#go-install). Any [version query](https://golang.org/ref/mod#version-queries) may be used instead of latest. This form of go install was added in Go 1.16, so projects supporting older versions may need to provide install instructions for both go install and go get. go get now reports an error when used outside a module, since there is no go.mod file to update. In GOPATH mode (with GO111MODULE=off), go get still builds and installs packages, as before.

I _think_ this change I'm suggesting is the right one.