### PR TITLE
Fix: Add error if `aws account-id` is empty string

### DIFF
--- a/kubernetes/install_kube_iam_user.sh
+++ b/kubernetes/install_kube_iam_user.sh
@@ -61,7 +61,7 @@ fi
 
 aws_account_id=$(aws account-id)
 
-if [ "$aws_account_id" == "" ]; then
+if [ -z "$aws_account_id" ]; then
   echo "Could not find valid AWS account ID for the provided profile (profile: \"$AWS_PROFILE\"). Please try again using valid AWS profile."
   exit 1
 fi

--- a/kubernetes/install_kube_iam_user.sh
+++ b/kubernetes/install_kube_iam_user.sh
@@ -59,6 +59,14 @@ if [ -n "$aws_profile" ]; then
   "
 fi
 
+aws_account_id=$(aws account-id)
+
+if [ "$aws_account_id" == "" ]; then
+  echo "Could not find valid AWS account ID for the provided profile (profile: \"$AWS_PROFILE\"). Please try again using valid AWS profile."
+  exit 1
+fi
+
+
 temp_user="$(mktemp)"
 temp_config="$(mktemp)"
 
@@ -73,7 +81,7 @@ users:
       - -i
       - $cluster
       - -r
-      - arn:aws:iam::$(aws account-id):role/$role
+      - arn:aws:iam::${aws_account_id}:role/$role
       command: aws-iam-authenticator
       env: $aws_profile_env" >"$temp_user"
 


### PR DESCRIPTION
@Milesjpool, @DanielBoa & I encountered a problem where the `aws account-id` was being set as an empty string. This should prevent the script from failing silently.