### PR TITLE
bump base images to fix builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     executor: default
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.11
       - checkout
       - prerequisites
       - run: make test_semver
@@ -34,7 +34,7 @@ jobs:
     executor: default
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.11
       - checkout
       - prerequisites
       - run: |
@@ -50,7 +50,7 @@ jobs:
     executor: default
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.11
       - checkout
       - prerequisites
       - run: |
@@ -67,7 +67,7 @@ jobs:
     executor: default
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.11
       - checkout
       - prerequisites
       - run: ./Dockerfile_node.sh "$CIRCLE_BRANCH"
@@ -79,7 +79,7 @@ jobs:
     executor: default
     steps:
       - setup_remote_docker:
-        version: 20.10.14
+          version: 20.10.11
       - checkout
       - prerequisites
       - run: sed "1cFROM node:<< parameters.node_version >>-alpine" Dockerfile_node > "Dockerfile_node_<< parameters.node_version >>"
@@ -90,7 +90,7 @@ jobs:
     executor: default
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.11
       - checkout
       - prerequisites
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
   shared_tests:
     executor: default
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - prerequisites
       - run: make test_semver
@@ -32,7 +33,8 @@ jobs:
   base:
     executor: default
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - prerequisites
       - run: |
@@ -47,7 +49,8 @@ jobs:
   kops:
     executor: default
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - prerequisites
       - run: |
@@ -63,7 +66,8 @@ jobs:
   node:
     executor: default
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - prerequisites
       - run: ./Dockerfile_node.sh "$CIRCLE_BRANCH"
@@ -74,7 +78,8 @@ jobs:
         type: string
     executor: default
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+        version: 20.10.14
       - checkout
       - prerequisites
       - run: sed "1cFROM node:<< parameters.node_version >>-alpine" Dockerfile_node > "Dockerfile_node_<< parameters.node_version >>"
@@ -84,7 +89,8 @@ jobs:
   kubernetes:
     executor: default
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - prerequisites
       - run: |

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.13
+FROM python:3.8-alpine3.16
 
 ENV SHELL /bin/bash
 

--- a/Dockerfile_base_test.py
+++ b/Dockerfile_base_test.py
@@ -60,7 +60,7 @@ def test_bats(host):
 
 
 def test_pip_packages(host):
-    packages = host.pip_package.get_packages()
+    packages = host.pip.get_packages()
     assert "awscli" in packages
     assert "credstash" in packages
     assert "docker-compose" in packages

--- a/Dockerfile_kops
+++ b/Dockerfile_kops
@@ -1,5 +1,5 @@
 
-FROM alpine:3.13.2 as kops
+FROM alpine:3.16 as kops
 ARG VERSION
 RUN apk add curl \
   && curl -L -s https://github.com/kubernetes/kops/releases/download/${VERSION}/kops-linux-amd64 -o /usr/local/bin/kops \

--- a/Dockerfile_node
+++ b/Dockerfile_node
@@ -1,4 +1,4 @@
-FROM node:14.15.5-alpine3.13
+FROM node:14-alpine3.16
 
 ENV PATH="./node_modules/.bin:${PATH}"
 ENV SHELL /bin/bash

--- a/Dockerfile_node_test.py
+++ b/Dockerfile_node_test.py
@@ -62,7 +62,7 @@ def test_bats(host):
 
 
 def test_pip_packages(host):
-    packages = host.pip_package.get_packages()
+    packages = host.pip.get_packages()
     assert "awscli" in packages
     assert "credstash" in packages
     assert "docker-compose" in packages


### PR DESCRIPTION
fixed failing builds https://app.circleci.com/pipelines/github/landtechnologies/docker-ci-images?branch=master

was failing due to packages trying to update core python deps and failing

have bumped container versions and had to upgrade the version of docker used to run the builds